### PR TITLE
Fix sourcemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ And then in browserify-jade-config.js:
     module.exports = {
         pretty: (process.env.NODE_ENV == 'production')?true:false
     };
+
+To disable sourcemap generation, which results in smaller compiled files for production builds,
+set jade option `compileDebug` to false in the options:
+
+    var b = browserify();
+    b.transform(require('browserify-jade').jade({
+        compileDebug: false
+    }));
+
+ or in package.json:
+
+     "browserify-jade": {
+        "compileDebug": false
+    }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pugify",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "browserify v2 plugin for jade with sourcemaps support",
   "main": "index.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "through": "~2.3.8"
   },
   "peerDependencies": {
-    "jade": "*"
+    "jade": "1.x"
   },
   "devDependencies": {
     "tap": "^5.4.4",


### PR DESCRIPTION
Source map generation is fixed for latest 1.11 jade. Note that additional changes will be needed for pug v2.0 as the compileDebug generated syntax has changed, so I have marked jade peer dependency as 1.x in package.json.

I have included option to skip source map generation which results in smaller generated code, even after source maps are removed from file. README has been updated to reflect this.

Compiled code has also been further optimised to remove more unneeded lines after generating source maps.