### PR TITLE
Move jade to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "browserify v2 plugin for jade with sourcemaps support",
   "main": "index.js",
   "dependencies": {
-    "browserify-transform-tools": "~1.5.1",
-    "convert-source-map": "~1.1.3",
+    "browserify-transform-tools": "~1.6.0",
+    "convert-source-map": "~1.2.0",
     "jade": "~1.11.0",
-    "source-map": "~0.5.3",
+    "source-map": "~0.5.6",
     "through": "~2.3.8"
   },
   "devDependencies": {
-    "tap": "^5.4.4",
-    "browserify": "^13.0.0"
+    "tap": "^5.7.2",
+    "browserify": "^13.0.1"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
   "dependencies": {
     "browserify-transform-tools": "~1.5.1",
     "convert-source-map": "~1.1.3",
+    "jade": "~1.11.0",
     "source-map": "~0.5.3",
     "through": "~2.3.8"
-  },
-  "peerDependencies": {
-    "jade": "1.x"
   },
   "devDependencies": {
     "tap": "^5.4.4",


### PR DESCRIPTION
According to #24 and #25 need to move jade from `peerDependencies`. 
The first main reason is that it doesn't install via npm3 and therefore tests fall (have tried after `git clone`).
The next reason is that in big project application can be installed with wrong jade version and therefore brokes at the start.