### PR TITLE
Emit compile error event

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,11 +46,15 @@ function getTransformFn(options) {
           }
         }
 
-        var result = compile(file, data, opts);
-        result.dependencies.forEach(function(dep) {
-          _this.emit('file', dep);
-        });
-        _this.queue(result.body);
+        try {
+          var result = compile(file, data, opts);
+          result.dependencies.forEach(function(dep) {
+            _this.emit('file', dep);
+          });
+          _this.queue(result.body);
+        } catch (e) {
+          _this.emit("error", e);
+        }
         _this.queue(null);
       });
     }
@@ -89,19 +93,19 @@ function withSourceMap(src, compiled, name) {
       var generatedLine = lineno + 2;
 
       if (originalLine > 0) {
-        generator.addMapping({
-          generated: {
-            line: generatedLine,
-            column: 0
-          },
-          source: name,
-          original: {
-            line: originalLine,
-            column: 0
-          }
-        });
+          generator.addMapping({
+            generated: {
+              line: generatedLine,
+              column: 0
+            },
+            source: name,
+            original: {
+              line: originalLine,
+              column: 0
+            }
+          });
+        }
       }
-    }
 
     var debugRe = /(pug|jade)(_|\.)debug\.(shift|unshift)\([^;]*\);/;
     var match;


### PR DESCRIPTION
When using watchify, any errors in the jade file cause the watchify process to crash. This pull request adjusts pugify so that it emits an error event instead of crashing. This can be used during the browserify or watchify bundling by using something like 

`.on('error', gulpUtil.log.bind(gulpUtil, 'Browserify Error'))`