### PR TITLE
Use config from closest package.json to source folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function getTransformFn(options) {
     }
     function end () {
       var _this = this;
-      configData = transformTools.loadTransformConfig('browserify-jade', file, function(err, configData) {
+      configData = transformTools.loadTransformConfig('browserify-jade', file, {fromSourceFileDir: true}, function(err, configData) {
         if(configData) {
           var config = configData.config || {};
           for(key in config) {


### PR DESCRIPTION
In the situation where you have different package.json files for subfolders in your application (e.g. for client vs server code), pugify was always reading the "browserify-jade" options from the topmost package.json file.

This pull request fixes this issue so that pugify reads the config from the package.json file closest to the source file being transformed. This matches the approach used by other transforms such as browserify-shim and stringify.