### PR TITLE
Updated to use pug v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-browserify-jade
-===============
+pugify
+======
 
-jade transform for browserify v2. Sourcemaps generation included.
+pug transform for browserify v2. Sourcemaps generation included.
 
 ![screen shot 2013-08-28 at 5 02 16 pm](https://f.cloud.github.com/assets/173025/1040229/e0555b3e-0faf-11e3-919a-b9c0b1489077.png)
 
@@ -10,41 +10,53 @@ jade transform for browserify v2. Sourcemaps generation included.
 
 ### Configuration
 
-If you are using browserify-jade programatically, you can pass options to the Jade compiler by
-calling `jade()` on the browserify-jade transform:
+If you are using pugify programatically, you can pass options to the Pug compiler by
+calling `pug()` on the pugify transform:
 
+```
     var b = browserify();
-    b.transform(require('browserify-jade').jade({
+    b.transform(require('pugify').pug({
         pretty: false
     }));
+```
 
-If you are using browserify-jade in a command line build, you can pass parameters by adding a
-"browserify-jade" section to your package.json.  You can either include parameters directly:
+If you are using pugify in a command line build, you can pass parameters by adding a
+"pugify" section to your package.json.  You can either include parameters directly:
 
-    "browserify-jade": {
+```
+    "pugify": {
         "pretty": false
     }
+```
 
 or for more complicated cases you can reference a .js file:
 
-    "browserify-jade": "./assets/browserify-jade-config.js"
+```
+    "pugify": "./assets/pugify-config.js"
+```
 
-And then in browserify-jade-config.js:
+And then in pugify-config.js:
 
+```
     module.exports = {
-        pretty: (process.env.NODE_ENV == 'production')?true:false
+        pretty: (process.env.NODE_ENV == 'production') ? true : false
     };
+```
 
 To disable sourcemap generation, which results in smaller compiled files for production builds,
-set jade option `compileDebug` to false in the options:
+set pug option `compileDebug` to false in the options:
 
+```
     var b = browserify();
-    b.transform(require('browserify-jade').jade({
+    b.transform(require('pugify').pug({
         compileDebug: false
     }));
+```
 
  or in package.json:
 
-     "browserify-jade": {
+```
+     "pugify": {
         "compileDebug": false
     }
+```

--- a/example/bar.js
+++ b/example/bar.js
@@ -1,4 +1,4 @@
-var tmpl = require('./foo.jade');
+var tmpl = require('./foo.pug');
 var data = require('./params.json');
 
 tmpl(data);

--- a/example/foo.pug
+++ b/example/foo.pug
@@ -1,3 +1,5 @@
+include fooinc.pug
+
 // test test test
 //- console.log('test1')
 - debugger;

--- a/example/fooinc.pug
+++ b/example/fooinc.pug
@@ -1,0 +1,4 @@
+h1 Header 1
+h2 Header 2
+h3 Header 3
+h4 Header 4

--- a/index.js
+++ b/index.js
@@ -1,171 +1,180 @@
 var fs = require('fs');
 
-var jade           = require('jade');
-var through        = require('through');
+var pug = require('pug');
+var through = require('through');
 var transformTools = require('browserify-transform-tools');
 
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
-var convert   = require('convert-source-map');
+var convert = require('convert-source-map');
 
-var PREFIX = "var jade = require('jade/lib/runtime.js');\nmodule.exports=";
+var PREFIX = "var pug = require('pug-runtime');\nmodule.exports=template;";
 
-var defaultJadeOptions = {
-  path: __dirname,
-  compileDebug: true,
-  pretty: true,
+var defaultPugOptions = {
+    path: __dirname,
+    compileDebug: true,
+    pretty: true,
 };
 
 function getTransformFn(options) {
-  var key;
-  var opts = {};
-  for(key in defaultJadeOptions) {
-    opts[key] = defaultJadeOptions[key];
-  }
-
-  options = options || {};
-  for(key in options) {
-    opts[key] = options[key];
-  }
-
-  return function (file) {
-    if (!/\.(pug|jade)$/.test(file)) return through();
-
-    var data = '';
-    return through(write, end);
-
-    function write (buf) {
-      data += buf;
+    var key;
+    var opts = {};
+    for (key in defaultPugOptions) {
+        opts[key] = defaultPugOptions[key];
     }
-    function end () {
-      var _this = this;
-      configData = transformTools.loadTransformConfig('browserify-jade', file, {fromSourceFileDir: true}, function(err, configData) {
-        if(configData) {
-          var config = configData.config || {};
-          for(key in config) {
-            opts[key] = config[key];
-          }
+
+    options = options || {};
+    for (key in options) {
+        opts[key] = options[key];
+    }
+
+    return function (file) {
+        if (!/\.(pug|jade)$/.test(file)) return through();
+
+        var data = '';
+        return through(write, end);
+
+        function write(buf) {
+            data += buf;
         }
 
-        try {
-          var result = compile(file, data, opts);
-          result.dependencies.forEach(function(dep) {
-            _this.emit('file', dep);
-          });
-          _this.queue(result.body);
-        } catch (e) {
-          _this.emit("error", e);
+        function end() {
+            var _this = this;
+            configData = transformTools.loadTransformConfig('pugify', file, { fromSourceFileDir: true }, function (err, configData) {
+                if (configData) {
+                    var config = configData.config || {};
+                    for (key in config) {
+                        opts[key] = config[key];
+                    }
+                }
+
+                try {
+                    var result = compile(file, data, opts);
+                    result.dependencies.forEach(function (dep) {
+                        _this.emit('file', dep);
+                    });
+                    _this.queue(result.body);
+                } catch (e) {
+                    _this.emit("error", e);
+                }
+                _this.queue(null);
+            });
         }
-        _this.queue(null);
-      });
-    }
-  };
+    };
 }
 
 module.exports = getTransformFn();
+module.exports.pug = getTransformFn;
 module.exports.jade = getTransformFn;
 module.exports.root = null;
 module.exports.register = register;
 
 function register() {
-  require.extensions['.pug'] = require.extensions['.jade'] = function(module, filename) {
-    var result = compile(filename, fs.readFileSync(filename, 'utf-8'), {compileDebug: true});
-    return module._compile(result.body, filename);
-  };
+    require.extensions['.pug'] = require.extensions['.jade'] = function (module, filename) {
+        var result = compile(filename, fs.readFileSync(filename, 'utf-8'), { compileDebug: true });
+        return module._compile(result.body, filename);
+    };
 }
 
-function replaceMatchWith(match, newContent)
-{
-  var src = match.input;
-  return src.slice(0, match.index) + newContent + src.slice(match.index + match[0].length);
+function replaceMatchWith(match, newContent) {
+    var src = match.input;
+    return src.slice(0, match.index) + newContent + src.slice(match.index + match[0].length);
 }
 
 function withSourceMap(src, compiled, name) {
 
-  var compiledLines = compiled.split('\n');
-  var generator = new SourceMapGenerator({file: name + '.js'});
+    var compiledLines = compiled.split('\n');
+    var generator = new SourceMapGenerator({ file: name + '.js' });
 
-  compiledLines.forEach(function(l, lineno) {
-    var oldFormat = false;
-    var generatedLine;
-    var linesMatched = {};
+    compiledLines.forEach(function (l, lineno) {
+        var oldFormat = false;
+        var generatedLine;
+        var linesMatched = {};
+        linesMatched[name] = {};
 
-    var m = l.match(/^jade(_|\.)debug\.unshift\(new jade\.DebugItem\( ([0-9]+)/);
-    // Check for older jade debug line format
-    if (!m) {
-      m = l.match(/^(pug|jade)(_|\.)debug\.unshift\(\{ lineno: ([0-9]+)/);
-      oldFormat = !!m;
-    }
-    if (m) {
-      var originalLine = Number(m[2]);
+        var m = l.match(/;pug_debug_line = ([0-9]+);/);
+        if (m) {
+            var originalLine = Number(m[1]);
 
-      if (originalLine > 0) {
+            if (originalLine > 0) {
+                var fname = "";
+                m = l.match(/;pug_debug_filename = \"(.*)\";/);
+                if (m) {
+                    fname = m[1].replace(/\\u002F/g, "/");
+                } else {
+                    fname = name;
+                }
+                if (!linesMatched[fname]) {
+                    // new include file - add to sourcemap
+                    linesMatched[fname] = {};
+                    try {
+                        var srcContent = fs.readFileSync(fname);
+                        generator.setSourceContent(fname, srcContent);
+                    } catch (e) {}
+                }
+                var alreadyMatched = linesMatched[fname][originalLine];
 
-        if (!linesMatched[originalLine] &&
-          (!/^jade_debug/.test(compiledLines[lineno+1]) || oldFormat))
-            generatedLine = lineno + 3; // 1-based and allow for PREFIX extra line
+                if (!alreadyMatched &&
+                    (!/^;pug_debug/.test(compiledLines[lineno + 1])))
+                    generatedLine = lineno + 3; // 1-based and allow for PREFIX extra line
 
-        if (generatedLine) {
+                if (generatedLine) {
+                    linesMatched[fname][originalLine] = true;
 
-          linesMatched[originalLine] = true;
-
-          generator.addMapping({
-            generated: {
-              line: generatedLine,
-              column: 0
-            },
-            source: name,
-            original: {
-              line: originalLine,
-              column: 0
+                    generator.addMapping({
+                        generated: {
+                            line: generatedLine,
+                            column: 0
+                        },
+                        source: fname,
+                        original: {
+                            line: originalLine,
+                            column: 0
+                        }
+                    });
+                }
             }
-          });
         }
-      }
+
+        //remove pug debug lines from within generated code
+        var debugRe = /;pug_debug_line = [0-9]+;pug_debug_filename = ".*";/;
+        var match;
+        while (match = l.match(debugRe)) {
+            l = replaceMatchWith(match, '');
+        }
+        compiledLines[lineno] = l;
+    });
+
+    // Remove pug debug lines at beginning and end of compiled version
+    // could be in a number of first few lines depending on source content
+    var found = false;
+    var line = 0;
+    while (!found && line < compiledLines.length) {
+        var lnDebug = compiledLines[line];
+        if (/^function pug_rethrow/.test(lnDebug)) {
+            found = true;
+            var re = /var\spug_debug_filename.*/;
+            compiledLines[line] = lnDebug.replace(re, '');
+        }
+        line++;
+    }
+    if (found) {
+        var ln = compiledLines.length;
+        compiledLines[ln - 1] = compiledLines[ln - 1].replace(/\} catch \(err\)[^}]*};/, '');
     }
 
-    var debugRe = /(pug|jade)(_|\.)debug\.(shift|unshift)\([^;]*\);/;
-    var match;
-    while(match = l.match(debugRe)) {
-      l = replaceMatchWith(match, '');
-    }
-    compiledLines[lineno] =l;
-  });
+    generator.setSourceContent(name, src);
 
-  // Remove jade debug lines at beginning and end of compiled version
-  if (/var jade_debug = /.test(compiledLines[1])) compiledLines[1] = '';
-  if (/try \{/.test(compiledLines[2])) compiledLines[2] = '';
-  var ln = compiledLines.length;
-  if (/\} catch \(err\) \{/.test(compiledLines[ln-4])) {
-    compiledLines[ln-2] = compiledLines[ln-3] = compiledLines[ln-4] = '';
-  }
-
-  generator.setSourceContent(name, src);
-
-  var map = convert.fromJSON(generator.toString());
-  compiledLines.push(map.toComment());
-  return compiledLines.join('\n');
+    var map = convert.fromJSON(generator.toString());
+    compiledLines.push(map.toComment());
+    return compiledLines.join('\n');
 }
 
 function compile(file, template, options) {
-    options.filename= file;
+    options.filename = file;
     var result;
-    if (jade.compileClientWithDependenciesTracked) {
-      result = jade.compileClientWithDependenciesTracked(template, options);
-    } else if (jade.compileClient) {
-      result = {
-        body: jade.compileClient(template, options).toString(),
-        dependencies: []
-      };
-    } else {
-      // jade < 1.0
-      options.client = true;
-      result = {
-        body: jade.compile(template, options).toString(),
-        dependencies: []
-      };
-    }
+    result = pug.compileClientWithDependenciesTracked(template, options);
     if (options.compileDebug)
-      result.body = withSourceMap(template, result.body, file);
+        result.body = withSourceMap(template, result.body, file);
 
     result.body = PREFIX + result.body;
     return result;

--- a/index.js
+++ b/index.js
@@ -46,11 +46,11 @@ function getTransformFn(options) {
           }
         }
 
-        var result = compile(file, data, opts);
-        result.dependencies.forEach(function(dep) {
-          _this.emit('file', dep);
-        });
-        _this.queue(result.body);
+          var result = compile(file, data, opts);
+          result.dependencies.forEach(function(dep) {
+            _this.emit('file', dep);
+          });
+          _this.queue(result.body);
         _this.queue(null);
       });
     }
@@ -81,25 +81,41 @@ function withSourceMap(src, compiled, name) {
   var generator = new SourceMapGenerator({file: name + '.js'});
 
   compiledLines.forEach(function(l, lineno) {
+    var oldFormat = false;
+    var generatedLine;
+    var linesMatched = {};
+
     var m = l.match(/^jade(_|\.)debug\.unshift\(new jade\.DebugItem\( ([0-9]+)/);
     // Check for older jade debug line format
-    if (!m) m = l.match(/^(pug|jade)(_|\.)debug\.unshift\(\{ lineno: ([0-9]+)/);
+    if (!m) {
+      m = l.match(/^(pug|jade)(_|\.)debug\.unshift\(\{ lineno: ([0-9]+)/);
+      oldFormat = !!m;
+    }
     if (m) {
       var originalLine = Number(m[2]);
-      var generatedLine = lineno + 2;
 
       if (originalLine > 0) {
-        generator.addMapping({
-          generated: {
-            line: generatedLine,
-            column: 0
-          },
-          source: name,
-          original: {
-            line: originalLine,
-            column: 0
-          }
-        });
+
+        if (!linesMatched[originalLine] &&
+          (!/^jade_debug/.test(compiledLines[lineno+1]) || oldFormat))
+            generatedLine = lineno + 3; // 1-based and allow for PREFIX extra line
+
+        if (generatedLine) {
+
+          linesMatched[originalLine] = true;
+
+          generator.addMapping({
+            generated: {
+              line: generatedLine,
+              column: 0
+            },
+            source: name,
+            original: {
+              line: originalLine,
+              column: 0
+            }
+          });
+        }
       }
     }
 
@@ -114,9 +130,9 @@ function withSourceMap(src, compiled, name) {
   // Remove jade debug lines at beginning and end of compiled version
   if (/var jade_debug = /.test(compiledLines[1])) compiledLines[1] = '';
   if (/try \{/.test(compiledLines[2])) compiledLines[2] = '';
-  var l = compiledLines.length;
-  if (/\} catch \(err\) \{/.test(compiledLines[l-4])) {
-    compiledLines[l-2] = compiledLines[l-3] = compiledLines[l-4] = '';
+  var ln = compiledLines.length;
+  if (/\} catch \(err\) \{/.test(compiledLines[ln-4])) {
+    compiledLines[ln-2] = compiledLines[ln-3] = compiledLines[ln-4] = '';
   }
 
   generator.setSourceContent(name, src);

--- a/package.json
+++ b/package.json
@@ -1,31 +1,33 @@
 {
   "name": "pugify",
-  "version": "1.0.5",
-  "description": "browserify v2 plugin for jade with sourcemaps support",
+  "version": "2.0.0",
+  "description": "browserify v2 plugin for pug with sourcemaps support",
   "main": "index.js",
   "dependencies": {
-    "browserify-transform-tools": "~1.6.0",
-    "convert-source-map": "~1.2.0",
-    "jade": "~1.11.0",
-    "source-map": "~0.5.6",
-    "through": "~2.3.8"
+    "convert-source-map": "~1.3.0",
+    "browserify-transform-tools": "^1.6.0",
+    "pug": "^2.0.0-beta6",
+    "source-map": "^0.5.6",
+    "through": "^2.3.8"
   },
   "devDependencies": {
-    "tap": "^5.7.2",
-    "browserify": "^13.0.1"
+    "browserify": "^13.1.0",
+    "pug-runtime": "^2.0.2",
+    "tap": "^5.7.2"
   },
   "scripts": {
     "test": "tap test/*.js"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/sidorares/browserify-jade.git"
+    "url": "git://github.com/sidorares/pugify.git"
   },
-  "homepage": "https://github.com/sidorares/browserify-jade",
+  "homepage": "https://github.com/sidorares/pugify",
   "keywords": [
     "browserify",
     "v2",
     "jade",
+    "pug",
     "plugin",
     "transform",
     "source maps",
@@ -35,6 +37,9 @@
     {
       "name": "Andrey Sidorov",
       "email": "sidorares@yandex.ru"
+    },
+    {
+      "name": "David Willis"
     }
   ],
   "license": "MIT"

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -17,7 +17,7 @@ test('options bundle', function(t) {
     t.plan(1);
     var b = browserify();
     b.add(__dirname + '/../example/bar.js');
-    b.transform(require('../index.js').jade({
+    b.transform(require('../index.js').pug({
         pretty: false
     }));
     b.bundle(function (err, src) {


### PR DESCRIPTION
This pull request updates pugify to use pug v2 for compilation and source map generation. At time of writing, the latest version of pug is 2.0.0-beta6 and all official website references to jade are now renamed as pug.

I have also updated the source map support so that any pug file includes are also added to the source maps and referenced correctly.

.jade and .pug template file extensions are both supported. 

.pug() is the new transform options method, but .jade() is retained for backwards compatibility.

The transform now uses the name "pugify" rather than "browserify-jade" when looking in package.json for config options. For this breaking change I have renumbered as 2.0.0.

README has also been updated to reflect these changes.
