### PR TITLE
Fixes for reported issues

### DIFF
--- a/example/foo.pug
+++ b/example/foo.pug
@@ -14,7 +14,7 @@ ul
       td= name
 
 
-
+p(data-bar='foo')&attributes({'data-foo':'bar'}) Paragraph with attributes
 
 
 - console.log(555)

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function withSourceMap(src, compiled, name) {
         }
 
         //remove pug debug lines from within generated code
-        var debugRe = /;pug_debug_line = [0-9]+;pug_debug_filename = ".*";/;
+        var debugRe = /;pug_debug_line = [0-9]+;(pug_debug_filename = ".*";)?/;
         var match;
         while (match = l.match(debugRe)) {
             l = replaceMatchWith(match, '');

--- a/index.js
+++ b/index.js
@@ -171,6 +171,7 @@ function withSourceMap(src, compiled, name) {
 
 function compile(file, template, options) {
     options.filename = file;
+    options.name = "template";
     var result;
     result = pug.compileClientWithDependenciesTracked(template, options);
     if (options.compileDebug)

--- a/index.js
+++ b/index.js
@@ -148,11 +148,11 @@ function withSourceMap(src, compiled, name) {
     // could be in a number of first few lines depending on source content
     var found = false;
     var line = 0;
+    var re = /var\spug_debug_filename.*/;
     while (!found && line < compiledLines.length) {
         var lnDebug = compiledLines[line];
-        if (/^function pug_rethrow/.test(lnDebug)) {
+        if (re.test(lnDebug)) {
             found = true;
-            var re = /var\spug_debug_filename.*/;
             compiledLines[line] = lnDebug.replace(re, '');
         }
         line++;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pugify",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "browserify v2 plugin for pug with sourcemaps support",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This pull request fixes the following errors:

* #35 Pug &attributes syntax incompatible with pugify compileDebug option
* #34 Pug "name" client option breaks pugify
* Error when using full stop terminated tag blocks (e.g. "p.") with compileDebug option
