### PR TITLE
Add options to compile pug to es2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ pug transform for browserify v2. Sourcemaps generation included.
 
 ### Configuration
 
+#### Format
+```javascript
+    var b = browserify();
+    # these options are passed directly to pug compiler
+    var pugConfig = {
+        pretty: false,
+        compileDebug: false
+    };
+    # if babelConfig is defined, the output will be transpiled using babel, and the options are passed into babel transpiler
+    # this is useful when you need to support old browsers, since pug compiles into ES6 format.
+    var babelConfig = {
+        presets: ['es2015']
+    };
+    b.transform(require('pugify').pug(pugConfig, babelConfig));
+```
+
 If you are using pugify programatically, you can pass options to the Pug compiler by
 calling `pug()` on the pugify transform:
 

--- a/example/es6.js
+++ b/example/es6.js
@@ -1,0 +1,2 @@
+var tmpl = require('./es6.pug');
+console.log(tmpl);

--- a/example/es6.pug
+++ b/example/es6.pug
@@ -1,0 +1,2 @@
+div(class=[`class1 class2 class${id}`, `new-${id}-class`])
+  | something

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var pug = require('pug');
 var through = require('through');
 var transformTools = require('browserify-transform-tools');
+var babel = require('babel-core');
 
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var convert = require('convert-source-map');
@@ -14,7 +15,7 @@ var defaultPugOptions = {
     pretty: true,
 };
 
-function getTransformFn(options) {
+function getTransformFn(options, babelOptions) {
     var key;
     var opts = {};
     for (key in defaultPugOptions) {
@@ -48,6 +49,9 @@ function getTransformFn(options) {
 
                 try {
                     var result = compile(file, data, opts);
+                    if (babelOptions && Object.keys(babelOptions).length > 0 && babelOptions.constructor === Object) {
+                      result.body = babel.transform(result.body, babelOptions).code;
+                    }
                     result.dependencies.forEach(function (dep) {
                         _this.emit('file', dep);
                     });

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "description": "browserify v2 plugin for pug with sourcemaps support",
   "main": "index.js",
   "dependencies": {
-    "convert-source-map": "~1.3.0",
+    "babel-core": "^6.26.0",
     "browserify-transform-tools": "^1.6.0",
+    "convert-source-map": "~1.3.0",
     "pug": "^2.0.0-beta6",
     "source-map": "^0.5.6",
     "through": "^2.3.8"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.24.1",
     "browserify": "^13.1.0",
     "pug-runtime": "^2.0.2",
     "tap": "^5.7.2"


### PR DESCRIPTION
resolves https://github.com/sidorares/pugify/issues/41

enable `pugify` output to be transpiled to `es2015` format (or what is needed via babel)

add `babelConfig` into transform function

new signature
`pugify.pug(pugConfig, babelConfig)`
where `babelConfig` is optional

test pending - will update if it's accepted